### PR TITLE
Add State to Service Worker Clients.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -322,6 +322,22 @@ Before Step #7.5 insert
 Adjust Step #7.8.2 to provide lifecycleState
 1. Let |client| be the result of running [=Create Window Client=] with <var ignore>newContext</var>'s {{Window}} object's [=environment settings object=], <var ignore>frameType</var>, <var ignore>visibilityState</var>, <var ignore>focusState</var>, <var ignore>ancestorOriginsList</var>, and |lifecycleState| as the arguments.
 
+#### <a href="https://w3c.github.io/ServiceWorker/#create-client-algorithm">`Create Client`</a> #### {#serviceworker-createclient-dfn}
+
+To Input append
+|lifecycleState|, a string
+
+After Step #2 in Output append
+1. Set <var ignore>clientObject</var>'s [=Client/lifecycle state=] to |lifecycleState|.
+
+#### <a href="https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm">`Create Window Client`</a> #### {#serviceworker-createwindowclient-dfn}
+
+To Input append
+|lifecycleState|, a string
+
+After Step #5 in Output append
+1. Set <var ignore>windowClient</var>'s [=Client/lifecycle state=] to |lifecycleState|.
+
 ### <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a>  ### {#serviceworker-algorithms-dfn}
 
 Append the following algorithm:
@@ -335,7 +351,7 @@ Append the following algorithm:
     :: |state|, a string
 
     1. Let |state| be {{ClientLifecycleState/"active"}}.
-    1. If |client|'s [=responsible document=] is [=frozen=], set |state| to be {{ClientLifecycleState/"frozen"}}.
+    1. If |client|'s [=environment settings object/global object=]'s [=owning document=] is [=frozen=], set |state| to be {{ClientLifecycleState/"frozen"}}
     1. Return |state|.
 </section>
 

--- a/spec.bs
+++ b/spec.bs
@@ -10,6 +10,7 @@ Editor: Domenic Denicola, Google https://google.com, d@domenic.me
 Repository: wicg/page-lifecycle
 Abstract: This document defines an API that supports browsers' ability to manage lifecycle of web pages.
 Default Biblio Status: current
+Markup Shorthands: markdown yes
 </pre>
 
 <pre class='link-defaults'>
@@ -255,7 +256,7 @@ Each {{HTMLMediaElement}} has a <dfn for="HTMLMediaElement">resume frozen flag</
 Modifications to the Service Worker Standard {#serviceworker-mod}
 --------------------------------------------
 
-### <a href="https://w3c.github.io/ServiceWorker/#client-interface"><code>Client</code></a> ### {#serviceworker-client-dfn}
+### <a href="https://w3c.github.io/ServiceWorker/#client-interface">`Client`</a> ### {#serviceworker-client-dfn}
 
 <pre class="idl">
     partial interface Client {
@@ -274,7 +275,7 @@ A {{Client}} object has an associated <dfn id="dfn-service-worker-client-lifecyc
 
 The <dfn attribute for="ServiceWorkerClient">lifecycleState</dfn> attribute <em>must</em> return the [=context object=]'s [=Client/lifecycle state=].
 
-### <a href="https://w3c.github.io/ServiceWorker/#clients-interface"><code>Clients</code></a> ### {#serviceworker-clients-dfn}
+### <a href="https://w3c.github.io/ServiceWorker/#clients-interface">`Clients`</a> ### {#serviceworker-clients-dfn}
 
 <pre class="idl">
     partial dictionary ClientQueryOptions {
@@ -288,7 +289,7 @@ The <dfn attribute for="ServiceWorkerClient">lifecycleState</dfn> attribute <em>
     };
 </pre>
 
-#### <a href="https://w3c.github.io/ServiceWorker/#clients-matchall"><code>matchAll(options)</code></a> #### {#serviceworker-matchall-dfn}
+#### <a href="https://w3c.github.io/ServiceWorker/#clients-matchall">`matchAll(options)`</a> #### {#serviceworker-matchall-dfn}
 
 Rename variable in Step #4.
 1. Let |matchedClientData| be a new [=list=].
@@ -313,7 +314,7 @@ Adjust Step #6.3
     1. [=Append=] |clientObject| to <var ignore>clientObjects</var>.
 
 
-#### <a href="https://w3c.github.io/ServiceWorker/#dom-clients-openwindow"><code>openWindow(url)</code></a> #### {#serviceworker-openwindow-dfn}
+#### <a href="https://w3c.github.io/ServiceWorker/#dom-clients-openwindow">`openWindow(url)`</a> #### {#serviceworker-openwindow-dfn}
 
 Before Step #7.5 insert
 1. Let |lifecycleState| be the result of running [=Get Client Lifecycle State=] with [=context object=]'s associated [=service worker client=].

--- a/spec.bs
+++ b/spec.bs
@@ -322,28 +322,12 @@ Before Step #7.5 insert
 Adjust Step #7.8.2 to provide lifecycleState
 1. Let |client| be the result of running [=Create Window Client=] with <var ignore>newContext</var>'s {{Window}} object's [=environment settings object=], <var ignore>frameType</var>, <var ignore>visibilityState</var>, <var ignore>focusState</var>, <var ignore>ancestorOriginsList</var>, and |lifecycleState| as the arguments.
 
-#### <a href="https://w3c.github.io/ServiceWorker/#create-client-algorithm">`Create Client`</a> #### {#serviceworker-createclient-dfn}
-
-To Input append
-|lifecycleState|, a string
-
-After Step #2 in Output append
-1. Set <var ignore>clientObject</var>'s [=Client/lifecycle state=] to |lifecycleState|.
-
-#### <a href="https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm">`Create Window Client`</a> #### {#serviceworker-createwindowclient-dfn}
-
-To Input append
-|lifecycleState|, a string
-
-After Step #5 in Output append
-1. Set <var ignore>windowClient</var>'s [=Client/lifecycle state=] to |lifecycleState|.
-
 ### <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a>  ### {#serviceworker-algorithms-dfn}
-
-Append the following algorithm:
 
 <section algorithm>
     #### <dfn>Get Client Lifecycle State</dfn> #### {#get-client-lifecycle-state-algorithm}
+
+    Append the following algorithm:
 
     : Input
     :: |client|, a [=/service worker client=]
@@ -355,6 +339,25 @@ Append the following algorithm:
     1. Return |state|.
 </section>
 
+<section algorithm="create-client-monkeypatch">
+    #### <a href="https://w3c.github.io/ServiceWorker/#create-client-algorithm">Create Client</a> #### {#serviceworker-createclient-dfn}
+
+    To Input append
+    |lifecycleState|, a string
+
+    After Step #2 in Output append
+    1. Set <var ignore>clientObject</var>'s [=Client/lifecycle state=] to |lifecycleState|.
+</section>
+
+<section algorithm="create-window-client-monkeypatch">
+    #### <a href="https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm">Create Window Client</a> #### {#serviceworker-createwindowclient-dfn}
+
+    To Input append
+    |lifecycleState|, a string
+
+    After Step #5 in Output append
+    1. Set <var ignore>windowClient</var>'s [=Client/lifecycle state=] to |lifecycleState|.
+</section>
 
 Page lifecycle processing model {#page-lifecycle}
 --------------------------------------------

--- a/spec.bs
+++ b/spec.bs
@@ -255,7 +255,7 @@ Each {{HTMLMediaElement}} has a <dfn for="HTMLMediaElement">resume frozen flag</
 Modifications to the Service Worker Standard {#serviceworker-mod}
 --------------------------------------------
 
-### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#client-interface">Client Interface</a> ### {#serviceworker-client-dfn}
+### <a href="https://w3c.github.io/ServiceWorker/#client-interface"><code>Client</code></a> ### {#serviceworker-client-dfn}
 
 <pre class="idl">
     partial interface Client {
@@ -268,15 +268,13 @@ Modifications to the Service Worker Standard {#serviceworker-mod}
     };
 </pre>
 
-A {{Client}} object has an associated <dfn id="dfn-service-worker-client-lifecycle-state" for="Client">lifecycleState</dfn>, which is one of the {{ClientLifecycleState}} enumeration values.
+A {{Client}} object has an associated <dfn id="dfn-service-worker-client-lifecycle-state" for="Client">lifecycle state</dfn>, which is one of the {{ClientLifecycleState}} enumeration values.
 
-<section>
-  <h4 id="service-worker-client-lifecycle-state">{{ServiceWorkerClient/lifecycleState}}</h4>
+#### {{ServiceWorkerClient/lifecycleState}} #### {#service-worker-client-lifecycle-state}
 
-  The <dfn attribute for="ServiceWorkerClient">lifecycleState</dfn> attribute <em>must</em> return the [=context object=]'s [=Client/lifecycleState=].
-</section>
+The <dfn attribute for="ServiceWorkerClient">lifecycleState</dfn> attribute <em>must</em> return the [=context object=]'s [=Client/lifecycle state=].
 
-### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#clients-interface">Clients Interface</a> ### {#serviceworker-clients-dfn}
+### <a href="https://w3c.github.io/ServiceWorker/#clients-interface"><code>Clients</code></a> ### {#serviceworker-clients-dfn}
 
 <pre class="idl">
     partial dictionary ClientQueryOptions {
@@ -290,8 +288,7 @@ A {{Client}} object has an associated <dfn id="dfn-service-worker-client-lifecyc
     };
 </pre>
 
-
-### Service Worker Algorithms: <a href="https://w3c.github.io/ServiceWorker/#clients-matchall">Match All</a> algorithm  ### {#serviceworker-matchall-dfn}
+#### <a href="https://w3c.github.io/ServiceWorker/#clients-matchall"><code>matchAll(options)</code></a> #### {#serviceworker-matchall-dfn}
 
 Rename variable in Step #4.
 1. Let |matchedClientData| be a new [=list=].
@@ -316,7 +313,7 @@ Adjust Step #6.3
     1. [=Append=] |clientObject| to <var ignore>clientObjects</var>.
 
 
-### Service Worker Algorithms: <a href="https://w3c.github.io/ServiceWorker/#dom-clients-openwindow">Open Window</a> algorithm  ### {#serviceworker-openwindow-dfn}
+#### <a href="https://w3c.github.io/ServiceWorker/#dom-clients-openwindow"><code>openWindow(url)</code></a> #### {#serviceworker-openwindow-dfn}
 
 Before Step #7.5 insert
 1. Let |lifecycleState| be the result of running [=Get Client Lifecycle State=] with [=context object=]'s associated [=service worker client=].
@@ -324,11 +321,12 @@ Before Step #7.5 insert
 Adjust Step #7.8.2 to provide lifecycleState
 1. Let |client| be the result of running [=Create Window Client=] with <var ignore>newContext</var>'s {{Window}} object's [=environment settings object=], <var ignore>frameType</var>, <var ignore>visibilityState</var>, <var ignore>focusState</var>, <var ignore>ancestorOriginsList</var>, and |lifecycleState| as the arguments.
 
-### Service Worker  <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a>  ### {#serviceworker-algorithms-dfn}
+### <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a>  ### {#serviceworker-algorithms-dfn}
+
 Append the following algorithm:
 
 <section algorithm>
-  <h5 id="get-client-lifecycle-state-algorithm"><dfn>Get Client Lifecycle State</dfn></h5>
+    #### <dfn>Get Client Lifecycle State</dfn> #### {#get-client-lifecycle-state-algorithm}
 
     : Input
     :: |client|, a [=/service worker client=]

--- a/spec.bs
+++ b/spec.bs
@@ -14,6 +14,11 @@ Default Biblio Status: current
 
 <pre class='link-defaults'>
 spec:dom; type:interface; text:Document
+spec: infra;
+    type: dfn;
+        text: list;
+        for: set; text: append
+        for: list; text: append
 </pre>
 
 <pre class='anchors'>
@@ -42,6 +47,9 @@ spec: ECMA262; urlPrefix: https://tc39.github.io/ecma262/;
     type: dfn; text: realm; url: #sec-code-realms
 spec: CSS-Houdini; urlPrefix: https://drafts.css-houdini.org/worklets;
     type: dfn; text: owning document; for: worklet; url: #workletglobalscope-owner-document
+spec: ServiceWorker; urlPrefix: https://w3c.github.io/ServiceWorker/
+    type: dfn; text: create window client; url: #create-windowclient-algorithm
+    type: dfn; text: create client; url: #create-client-algorithm
 </pre>
 
 
@@ -251,66 +259,84 @@ Modifications to the Service Worker Standard {#serviceworker-mod}
 
 <pre class="idl">
     partial interface Client {
-        readonly attribute  ClientState state;
+        readonly attribute ClientLifecycleState lifecycleState;
     };
 
-    enum ClientState {
+    enum ClientLifecycleState {
         "active",
         "frozen"
     };
 </pre>
 
-A {{Client}} object has an associated <dfn id="dfn-service-worker-client-state" for="Client">state</dfn>, which is one of {{ClientState}} attribute value.
+A {{Client}} object has an associated <dfn id="dfn-service-worker-client-lifecycle-state" for="Client">lifecycleState</dfn>, which is one of the {{ClientLifecycleState}} enumeration values.
 
 <section>
-  <h4 id="service-worker-client-state">{{ServiceWorkerClient/state}}</h4>
+  <h4 id="service-worker-client-lifecycle-state">{{ServiceWorkerClient/lifecycleState}}</h4>
 
-  The <dfn attribute for="ServiceWorkerClient">state</dfn> attribute *must* return the [=context object=]'s [=Client/state=].
+  The <dfn attribute for="ServiceWorkerClient">lifecycleState</dfn> attribute <em>must</em> return the [=context object=]'s [=Client/lifecycleState=].
 </section>
 
 ### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#clients-interface">Clients Interface</a> ### {#serviceworker-clients-dfn}
 
 <pre class="idl">
     partial dictionary ClientQueryOptions {
-        ClientStateQuery state = "active";
+        ClientLifecycleStateQuery lifecycleState = "active";
     };
 
-    enum ClientStateQuery {
+    enum ClientLifecycleStateQuery {
         "active",
         "frozen",
         "all"
     };
 </pre>
 
-Adjust <a href="https://w3c.github.io/ServiceWorker/#clients-matchall">Match All</a> algorithm:
+
+### Service Worker Algorithms: <a href="https://w3c.github.io/ServiceWorker/#clients-matchall">Match All</a> algorithm  ### {#serviceworker-matchall-dfn}
+
+Rename variable in Step #4.
+1. Let |matchedClientData| be a new [=list=].
 
 Before Step #2.5.1 insert
 
-1. Let <var ignore>state</var> be the result of running [=Get Client State=] with <var ignore>client</var>.
-1. If <var ignore>options</var>["{{ClientQueryOptions/state}}"] is not {{ClientStateQuery/"all"}} and does not equal <var ignore>state</var>, then [=continue=].
+1. Let <var ignore>lifecycleState</var> be the result of running [=Get Client Lifecycle State=] with <var ignore>client</var>.
+1. If <var ignore>options</var>["{{ClientQueryOptions/lifecycleState}}"] is not {{ClientLifecycleStateQuery/"all"}} and does not equal <var ignore>lifecycleState</var>, then [=continue=].
+
+Append lifecycleState to list in Step #5.3.1
+1. Let |windowData| be «[ "client" → |client|, "ancestorOriginsList" → a new [=list=], "lifecycleState" → |lifecycleState| ]».
+
+Append lifecycleState to matchedClientData in Step #5.4
+1. Add «[ "client" → |client|, "lifecycleState" → |lifecycleState| ]» to |matchedClientData|.
+
+Pass windowData lifecycleState into Create Window Client algorithm in Step #6.2
+1. Let <var ignore>windowClient</var> be the result of running [=Create Window Client=] algorithm with |windowData|["`client`"], |windowData|["`frameType`"], |windowData|["`visibilityState`"], |windowData|["`focusState`"], |windowData|["`ancestorOriginsList`"], and |windowData|["`lifecycleState`"] as the arguments.
+
+Adjust Step #6.3
+1. [=list/For each=] |clientData| in |matchedClientData|:
+    1. Let |clientObject| be the result of running [=Create Client=] algorithm with |clientData|["`client`"], and |clientData|["`lifecycleState`"] as the arguments.
+    1. [=Append=] |clientObject| to <var ignore>clientObjects</var>.
 
 
-<section>
-  <h4 id="client-state">{{Client/state}}</h4>
+### Service Worker Algorithms: <a href="https://w3c.github.io/ServiceWorker/#dom-clients-openwindow">Open Window</a> algorithm  ### {#serviceworker-openwindow-dfn}
 
-  The <dfn attribute for="Client">state</dfn> attribute *must* return the [=context object=]'s [=Client/state=].
-</section>
+Before Step #7.5 insert
+1. Let |lifecycleState| be the result of running [=Get Client Lifecycle State=] with [=context object=]'s associated [=service worker client=].
 
+Adjust Step #7.8.2 to provide lifecycleState
+1. Let |client| be the result of running [=Create Window Client=] with <var ignore>newContext</var>'s {{Window}} object's [=environment settings object=], <var ignore>frameType</var>, <var ignore>visibilityState</var>, <var ignore>focusState</var>, <var ignore>ancestorOriginsList</var>, and |lifecycleState| as the arguments.
 
-### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a> ### {#serviceworker-algorithms-dfn}
-
+### Service Worker  <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a>  ### {#serviceworker-algorithms-dfn}
 Append the following algorithm:
 
 <section algorithm>
-  <h3 id="get-client-state-algorithm"><dfn>Get Client State</dfn></h3>
+  <h5 id="get-client-lifecycle-state-algorithm"><dfn>Get Client Lifecycle State</dfn></h5>
 
     : Input
     :: |client|, a [=/service worker client=]
     : Output
     :: |state|, a string
 
-    1. Let |state| be {{ClientState/"active"}}.
-    1. If |client|'s [=responsible document=] is [=frozen=], set |state| to be {{ClientState/"frozen"}}.
+    1. Let |state| be {{ClientLifecycleState/"active"}}.
+    1. If |client|'s [=responsible document=] is [=frozen=], set |state| to be {{ClientLifecycleState/"frozen"}}.
     1. Return |state|.
 </section>
 

--- a/spec.bs
+++ b/spec.bs
@@ -244,6 +244,77 @@ Run the [=update document frozenness steps=] given <var ignore>child document</v
 
 Each {{HTMLMediaElement}} has a <dfn for="HTMLMediaElement">resume frozen flag</dfn>, which is initially set to false.
 
+Modifications to the Service Worker Standard {#serviceworker-mod}
+--------------------------------------------
+
+### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#client-interface">Client Interface</a> ### {#serviceworker-client-dfn}
+
+<pre class="idl">
+    partial interface Client {
+        readonly attribute  ClientState state;
+    };
+
+    enum ClientState {
+        "active",
+        "frozen"
+    };
+</pre>
+
+A {{Client}} object has an associated <dfn id="dfn-service-worker-client-state" for="Client">state</dfn>, which is one of {{ClientState}} attribute value.
+
+<section>
+  <h4 id="service-worker-client-state">{{ServiceWorkerClient/state}}</h4>
+
+  The <dfn attribute for="ServiceWorkerClient">state</dfn> attribute *must* return the [=context object=]'s [=Client/state=].
+</section>
+
+### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#clients-interface">Clients Interface</a> ### {#serviceworker-clients-dfn}
+
+<pre class="idl">
+    partial dictionary ClientQueryOptions {
+        ClientStateQuery state = "active";
+    };
+
+    enum ClientStateQuery {
+        "active",
+        "frozen",
+        "all"
+    };
+</pre>
+
+Adjust <a href="https://w3c.github.io/ServiceWorker/#clients-matchall">Match All</a> algorithm:
+
+Before Step #2.5.1 insert
+
+1. Let <var ignore>state</var> be the result of running [=Get Client State=] with <var ignore>client</var>.
+1. If <var ignore>options</var>["{{ClientQueryOptions/state}}"] is not {{ClientStateQuery/"all"}} and does not equal <var ignore>state</var>, then [=continue=].
+
+
+<section>
+  <h4 id="client-state">{{Client/state}}</h4>
+
+  The <dfn attribute for="Client">state</dfn> attribute *must* return the [=context object=]'s [=Client/state=].
+</section>
+
+
+### Service Worker: <a href="https://w3c.github.io/ServiceWorker/#algorithms">Algorithms</a> ### {#serviceworker-algorithms-dfn}
+
+Append the following algorithm:
+
+<section algorithm>
+  <h3 id="get-client-state-algorithm"><dfn>Get Client State</dfn></h3>
+
+    : Input
+    :: |client|, a [=/service worker client=]
+    : Output
+    :: |state|, a string
+
+    1. Let |state| be {{ClientState/"active"}}.
+    1. If |client|'s [=responsible document=] is [=frozen=], set |state| to be {{ClientState/"frozen"}}.
+    1. Return |state|.
+</section>
+
+
 Page lifecycle processing model {#page-lifecycle}
 --------------------------------------------
 


### PR DESCRIPTION
As discussed on https://github.com/w3c/ServiceWorker/pull/1442

Unfortunately adoption of page-lifecycle is yet to be formally
supported by other vendors so we need to monkey patch this in the
page lifecycle spec.
